### PR TITLE
feat: extend properties with heating circuit and boiler sensors (all readonly)

### DIFF
--- a/src/conf/config.yaml
+++ b/src/conf/config.yaml
@@ -103,7 +103,7 @@ Properties:
 
   # --- Betriebsart & System ---
   BetriebArtM1:
-    readonly: true
+    readonly: false
     interval: 3600
   SystemTime:
     readonly: true

--- a/src/conf/config.yaml
+++ b/src/conf/config.yaml
@@ -16,12 +16,17 @@ VControld:
 # readonly: true = sensor only, false = controllable
 # interval: update interval in seconds
 Properties:
+  # --- Außentemperatur ---
   TempA:
     readonly: true
     interval: 300
+
+  # --- Warmwasser ---
   TempWWist:
     readonly: true
     interval: 300
+
+  # --- Solar ---
   TempKol:
     readonly: true
     interval: 300
@@ -31,14 +36,74 @@ Properties:
   SolarLeistung:
     readonly: true
     interval: 3600
+  TempSpu:                  # Solar Speichertemperatur unten
+    readonly: true
+    interval: 300
+
+  # --- Brenner ---
   BrennerStarts:
     readonly: true
     interval: 300
   BrennerStunden1:
     readonly: true
     interval: 3600
+  BrennerStatus:            # Brenner an/aus (wichtig für Takt-Analyse)
+    readonly: true
+    interval: 60
+
+  # --- Kessel ---
+  TempKist:                 # Kesseltemperatur Ist
+    readonly: true
+    interval: 60
+  TempKsoll:                # Kesselsolltemperatur
+    readonly: true
+    interval: 60
+  TempAbgas:                # Abgastemperatur
+    readonly: true
+    interval: 300
+
+  # --- Heizkreis A1 ---
+  TempVListM1:              # Vorlauftemperatur Ist A1
+    readonly: true
+    interval: 60
+  TempVLsollM1:             # Vorlauftemperatur Soll A1
+    readonly: true
+    interval: 60
+  TempRL17A:                # Rücklauftemperatur
+    readonly: true
+    interval: 60
+  NeigungM1:                # Heizkurven-Neigung A1
+    readonly: true
+    interval: 3600
+  NiveauM1:                 # Heizkurven-Niveau A1
+    readonly: true
+    interval: 3600
+  TempRaumNorSollM1:        # Raumsolltemperatur Normalbetrieb A1
+    readonly: true
+    interval: 3600
+  PumpeStatusM1:            # Heizkreispumpe A1 Status
+    readonly: true
+    interval: 60
+  PumpeDrehzahlM1:          # Heizkreispumpe A1 Drehzahl
+    readonly: true
+    interval: 60
+
+  # --- Interne Pumpe ---
+  PumpeStatusIntern:
+    readonly: true
+    interval: 60
+  PumpeDrehzahlIntern:
+    readonly: true
+    interval: 60
+
+  # --- Zirkulation ---
+  PumpeStatusZirku:
+    readonly: true
+    interval: 300
+
+  # --- Betriebsart & System ---
   BetriebArtM1:
-    readonly: false
+    readonly: true
     interval: 3600
   SystemTime:
     readonly: true


### PR DESCRIPTION
## Changes

Extended `config.yaml` with additional Viessmann sensors for heating curve optimization.

**All new values are `readonly: true`** — no write access until explicitly enabled and tested.

### Added

**Boiler:**
- `TempKist` — Boiler temperature actual (60s)
- `TempKsoll` — Boiler temperature setpoint (60s)
- `TempAbgas` — Flue gas temperature (300s)
- `BrennerStatus` — Burner on/off (60s, important for short-cycling analysis)

**Heating circuit A1:**
- `TempVListM1` — Flow temperature actual (60s)
- `TempVLsollM1` — Flow temperature setpoint (60s)
- `TempRL17A` — Return temperature (60s)
- `NeigungM1` — Heating curve slope (3600s)
- `NiveauM1` — Heating curve level (3600s)
- `TempRaumNorSollM1` — Room temperature setpoint normal mode (3600s)
- `PumpeStatusM1` + `PumpeDrehzahlM1` — Heating pump status + speed (60s)

**Pumps:**
- `PumpeStatusIntern` + `PumpeDrehzahlIntern` — Internal pump status + speed (60s)
- `PumpeStatusZirku` — Circulation pump status (300s)

**Solar:**
- `TempSpu` — Solar storage temperature bottom (300s)

### Goal
The new sensors allow analysis of burner short-cycling (currently ~100 starts/day)
and stepwise optimization of the heating curve slope (currently 1.0, target 0.6).