### PR TITLE
fix: set retain=True as default for publish_state

### DIFF
--- a/src/pyvclient/ha/ha_mqtt_discovery.py
+++ b/src/pyvclient/ha/ha_mqtt_discovery.py
@@ -169,7 +169,7 @@ class HAMqttClient:
             self.client.subscribe(topic)
             logger.info(f"Subscribed to command topic: {topic}")
 
-    def publish_state(self, topic: str, state: Any, retain: bool = False):
+    def publish_state(self, topic: str, state: Any, retain: bool = True):
         """
         Publish state value to topic.
 


### PR DESCRIPTION
## Problem

After a Home Assistant restart, several Viessmann sensors showed as unavailable (grey) — especially entities with long polling intervals (NeigungM1, NiveauM1, BrennerStunden1, SolarStunden at 3600s).

## Root Cause

`publish_state()` had `retain=False` as default. Without retained messages, the MQTT broker discards state values. After HA reconnects, it subscribes to the topics but receives nothing until the next poll cycle — which can take up to an hour.

## Fix

Changed default to `retain=True`. The broker now stores the last published value for every state topic. HA receives the current value immediately on restart/reconnect.

This is the correct behavior for all entity types (sensor, select, number) — retain on state topics causes no side effects. Command topics (HA → pyvclient) are unaffected.